### PR TITLE
エラー原因を特定しやすくするため、パーサーのカラム名の命名規則を変更しました

### DIFF
--- a/app/models/repositories/CommentRepository.scala
+++ b/app/models/repositories/CommentRepository.scala
@@ -3,10 +3,12 @@ package models.repositories
 import models.DatabaseExecutionContext
 import models.domains.Comment
 
-import play.api.db.DBApi
 import anorm._
+import anorm.SqlParser._
+import play.api.db.DBApi
 
 import javax.inject.Inject
+import java.time.LocalDateTime
 
 class CommentRepository @Inject() (
     dbApi: DBApi
@@ -15,6 +17,17 @@ class CommentRepository @Inject() (
 ) {
   private val db = dbApi.database("default")
 
-  private[repositories] val simple: RowParser[Comment] =
-    Macro.namedParser[Comment](Macro.ColumnNaming.SnakeCase)
+//   private[repositories] val simple: RowParser[Comment] =
+//     Macro.namedParser[Comment](Macro.ColumnNaming.SnakeCase)
+
+  private[repositories] val simple = {
+    get[Option[Long]]("c_comment_id") ~
+      get[Option[Long]]("c_user_id") ~
+      get[Option[Long]]("c_post_id") ~
+      get[String]("c_content") ~
+      get[Option[LocalDateTime]]("c_commented_at") map {
+        case commentId ~ userId ~ postId ~ content ~ commentedAt =>
+          Comment(commentId, userId, postId, content, commentedAt)
+      }
+  }
 }

--- a/app/models/repositories/UserRepository.scala
+++ b/app/models/repositories/UserRepository.scala
@@ -22,8 +22,14 @@ class UserRepository @Inject() (dbApi: DBApi)(implicit
     Macro.namedParser[User](Macro.ColumnNaming.SnakeCase)
 
   // 投稿一覧取得の際に使用する
-  private[repositories] val userWhoPostedParser: RowParser[UserWhoPosted] =
-    Macro.namedParser[UserWhoPosted](Macro.ColumnNaming.SnakeCase)
+  private[repositories] val userWhoPostedParser = {
+    get[Long]("u_user_id") ~
+      get[String]("u_name") ~
+      get[Option[String]]("u_profile_img") map {
+        case userId ~ name ~ profileImg =>
+          UserWhoPosted(userId, name, profileImg)
+      }
+  }
 
   def findUserById(id: Long): Future[Option[User]] = Future {
     db.withConnection { implicit con =>

--- a/app/views/posts/detail.scala.html
+++ b/app/views/posts/detail.scala.html
@@ -1,6 +1,45 @@
 @import domains.Post
+@import java.time.format._
 @(post: Post)
 @main("投稿詳細"){
-	<h1>投稿詳細ページ</h1>
-
+<div class="container main-contents">
+	<div class="page-title text-center mt-5">
+		<h1 class="fw-bold">
+			投稿詳細ページ
+		</h1>
+		<span class="text-secondary">({ログインユーザ}さん)</span>
+	</div>
+	<article class="border">
+			<section class="card-header bg-white">
+				<span class="fs-5 fw-bold">@post.user.name</span>
+				<span class="ps-3 text-secondary">
+					@post.postedAt.format(DateTimeFormatter.ofPattern("MM/dd hh:mm"))
+				</span>
+			</section>
+			<section class="card-body">
+				<div class="card-text p-3">@post.content</div>
+				<div class="px-3 w-25 d-flex justify-content-between">
+					<i title="コメントする" class="far fa-comment"></i>
+					<i title="いいね！" class="far fa-heart"></i>
+				</div>
+			</section>
+	</article>
+	@post.commentList.map{comment =>
+		<article class="border">
+			<section class="card-header bg-white">
+				<span class="fs-5 fw-bold">@comment.user.name</span>
+				<span class="ps-3 text-secondary">
+					@comment.commentedAt
+				</span>
+			</section>
+			<section class="card-body">
+				<div class="card-text p-3">@comment.content</div>
+				<div class="px-3 w-25 d-flex justify-content-between">
+					<i title="コメントする" class="far fa-comment"></i>
+					<i title="いいね！" class="far fa-heart"></i>
+				</div>
+			</section>
+	</article>
+	}
+</div>
 }

--- a/app/views/posts/detail.scala.html
+++ b/app/views/posts/detail.scala.html
@@ -27,7 +27,7 @@
 	@post.commentList.map{comment =>
 		<article class="border">
 			<section class="card-header bg-white">
-				<span class="fs-5 fw-bold">@comment.user.name</span>
+				<span class="fs-5 fw-bold">@comment.userId</span>
 				<span class="ps-3 text-secondary">
 					@comment.commentedAt
 				</span>

--- a/conf/evolutions/default/2.sql
+++ b/conf/evolutions/default/2.sql
@@ -10,11 +10,11 @@ INSERT INTO posts (content,user_id,posted_at) VALUES ('user1投稿2', 1, NOW());
 INSERT INTO posts (content,user_id,posted_at) VALUES ('user2投稿1', 2, NOW());
 INSERT INTO posts (content,user_id,posted_at) VALUES ('user2投稿2', 2, NOW());
 
-INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (1,1,'user1のpost1に対するコメント1',NOW());
-INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (1,1,'user1のpost1に対するコメント2',NOW());
-INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (1,1,'user1のpost1に対するコメント3',NOW());
-INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (1,1,'user1のpost1に対するコメント4',NOW());
-INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (1,1,'user1のpost1に対するコメント5',NOW());
+INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (2,1,'user1のpost1に対するコメント1',NOW());
+INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (2,1,'user1のpost1に対するコメント2',NOW());
+INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (2,1,'user1のpost1に対するコメント3',NOW());
+INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (3,1,'user1のpost1に対するコメント4',NOW());
+INSERT INTO comments (user_id, post_id, content, commented_at) VALUES (3,1,'user1のpost1に対するコメント5',NOW());
 
 INSERT INTO likes (user_id, post_id) VALUES(1,1);
 INSERT INTO likes (user_id, post_id) VALUES(1,2);
@@ -22,7 +22,12 @@ INSERT INTO likes (user_id, post_id) VALUES(2,1);
 
 --!Downs
 DELETE FROM likes;
+SELECT setval ('likes_like_id_seq', 1, false);
 DELETE FROM comments;
+SELECT setval ('comments_comment_id_seq', 1, false);
 DELETE FROM posts;
+SELECT setval ('posts_post_id_seq', 1, false);
 DELETE FROM users;
+SELECT setval ('users_user_id_seq', 1, false);
 DELETE FROM departments;
+SELECT setval ('departments_department_id_seq', 1, false);


### PR DESCRIPTION
エラー原因を特定しやすくするため、パーサーのカラム名の命名規則を変更しました